### PR TITLE
[ENH] Allow output terminal to be set by user

### DIFF
--- a/src/plot/base.cr
+++ b/src/plot/base.cr
@@ -224,9 +224,9 @@ class AquaPlot::PlotBase(T) < AquaPlot::GlobalPlotOptions
     end
   end
 
-  def savefig(fname : String)
+  def savefig(fname : String, terminal : String = "png")
     save_term = @terminal
-    self.set_terminal("png")
+    self.set_terminal(terminal)
     self.set_output(fname)
     self.show
     self.set_output("")


### PR DESCRIPTION
Closes #19 

```crystal
fns = ["sin(x)", "cos(x)", "tan(x)", "atan(x)", "asin(x)"].map do |fn|
  AquaPlot::Function.new fn
end

plt = AquaPlot::Plot.new fns
plt.savefig("test.pdf", "pdf")
plt.close
```