### PR TITLE
Add from_points as array

### DIFF
--- a/src/series/base.cr
+++ b/src/series/base.cr
@@ -146,6 +146,10 @@ abstract class AquaPlot::XYZ < AquaPlot::SeriesOptions
   end
 
   def self.from_points(*points : Tuple(U, V, W)) forall U, V, W
+    from_points(points.to_a)
+  end
+
+  def self.from_points(points : Array(Tuple(U, V, W))) forall U, V, W
     x = [] of U
     y = [] of V
     z = [] of W


### PR DESCRIPTION
Arrays are more permissive than Tuples.

This allow adding dynamically calculated points to the scatter.